### PR TITLE
Fixed invalid cast of a hashset to a list

### DIFF
--- a/src/org/plugin/dot/contributors/DotChooseByNameContributor.java
+++ b/src/org/plugin/dot/contributors/DotChooseByNameContributor.java
@@ -26,7 +26,7 @@ public class DotChooseByNameContributor implements ChooseByNameContributor {
   @Override
   public NavigationItem[] getItemsByName(String name, String pattern, Project project, boolean includeNonProjectItems) {
     // todo include non project items
-    List<DotId> properties = (List<DotId>) DotPSITreeUtil.findDotIds(project, name);
+    Set<DotId> properties = (Set<DotId>) DotPSITreeUtil.findDotIds(project, name);
     return properties.toArray(new NavigationItem[properties.size()]);
   }
 }


### PR DESCRIPTION
The cast from a hashset to a list results in an exception and is not necessary (because Set has toArray method).
Addresses this issue #28 